### PR TITLE
Opens sci-hub link in same tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Option to open sci-hub paper in current tab rather than new tab

--- a/options.html
+++ b/options.html
@@ -8,6 +8,10 @@
       <p style="margin-right: 1em;">Sci-Hub url:</p>
       <input type="text" id="url"/>
     </div>
+    <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
+      <p style="margin-right: 1em;">Open in new tab:</p>
+      <input type="checkbox" id="newtab" value="true"/>
+    </div>
     <div>
       <p>
         Please visit the <a href="https://github.com/gchenfc/sci-hub-now/issues">github</a> to give feedback.

--- a/options.js
+++ b/options.js
@@ -1,19 +1,34 @@
 'use strict';
 
-function getUrl(field) {
-  chrome.storage.local.get(['scihub-url'], function (result) {
-    field.value = result['scihub-url'];
+function updatePageString(field, propname) {
+  chrome.storage.local.get([propname], function (result) {
+    field.value = result[propname];
   })
 }
-
-function setUrl(url) {
-  chrome.storage.local.set({'scihub-url': url}, function () {})
+function updatePageBool(field, propname) {
+  chrome.storage.local.get([propname], function (result) {
+    field.checked = result[propname];
+  })
+}
+function updateStorage(val, propname) {
+  var obj = {};
+  obj[propname] = val;
+  chrome.storage.local.set(obj, function () {});
   var bgPage = chrome.extension.getBackgroundPage();
-  bgPage.setUrl(url);
+  bgPage.setthing(propname, val);
+}
+function updateStuffString(field, propname) {
+  updatePageString(field, propname);
+  field.onkeyup = function () {
+    updateStorage(field.value, propname);
+  }
+}
+function updateStuffBool(field, propname) {
+  updatePageBool(field, propname);
+  field.onchange = function () {
+    updateStorage(field.checked, propname);
+  }
 }
 
-var urlField = document.getElementById("url");
-getUrl(urlField);
-urlField.onkeyup = function () {
-  setUrl(urlField.value);
-};
+updateStuffString(document.getElementById("url"), "scihub-url");
+updateStuffBool(document.getElementById("newtab"), "open-in-new-tab");


### PR DESCRIPTION
Adds an option to open the sci-hub link in the same tab rather than a new tab (same tab by default).

![image](https://user-images.githubusercontent.com/25356161/104134549-526c7880-5358-11eb-8fe4-a9b7aa685f21.png)
