### PR TITLE
List of backup mirrors in options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 ### Added
 - List of active sci-hub links and javascript status checker
   - In the options page, a table of active links is populated from a github json file and color-coded green/red for working/not working
+  - Upon requesting a paper, the extension will auto-check if the server is not working and prompt the user to go to the options page to select a working link.
 - Option to open sci-hub paper in current tab rather than new tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,6 @@
 ## [Unreleased]
 
 ### Added
+- List of active sci-hub links and javascript status checker
+  - In the options page, a table of active links is populated from a github json file and color-coded green/red for working/not working
 - Option to open sci-hub paper in current tab rather than new tab

--- a/activelinks.json
+++ b/activelinks.json
@@ -1,0 +1,7 @@
+[
+"https://sci-hub.st/",
+"http://sci-hub.ee/",
+"https://sci-hub.ee/",
+"https://sci-hub.se/",
+"https://sci-hub.do/"
+]

--- a/background.js
+++ b/background.js
@@ -7,9 +7,11 @@ const doiRegex = new RegExp(
 var sciHubUrl;
 const trueRed = "#BC243C";
 var openInNewTab = false;
+var autoCheckServer = true;
 const defaults = {
   "scihub-url": "https://sci-hub.st/",
-  "open-in-new-tab": false
+  "open-in-new-tab": false,
+  "autocheck-server": true
 };
 
 function resetBadgeText() {
@@ -23,6 +25,9 @@ function setthing(name, value) {
       break;
     case "open-in-new-tab":
       openInNewTab = value;
+      break;
+    case "autocheck-server":
+      autoCheckServer = value;
       break;
   }
 }
@@ -61,7 +66,9 @@ function getHtml(htmlSource) {
     } else {
       browser.tabs.update(undefined, {url: sciHubUrl + foundRegex});
     }
-    checkServerStatus();
+    if (autoCheckServer) {
+      checkServerStatus();
+    }
   } else {
     browser.browserAction.setBadgeTextColor({ color: "white" });
     browser.browserAction.setBadgeBackgroundColor({ color: trueRed });

--- a/background.js
+++ b/background.js
@@ -35,6 +35,17 @@ function initialize(name) {
     setthing(name, result[name]);
   })
 }
+function checkServerStatus() {
+  var img = document.body.appendChild(document.createElement("img"));
+  img.height = 0;
+  img.visibility = "hidden";
+  img.onerror = function () {
+    if (confirm("Looks like "+sciHubUrl+" is dead.  Would you like to go to the options page to select a different mirror?")) {
+      browser.tabs.create({url: 'chrome://extensions/?options=' + chrome.runtime.id}).then();
+    }
+  }
+  img.src = sciHubUrl + "/misc/img/raven_1.png";
+}
 
 function getHtml(htmlSource) {
   htmlSource = htmlSource[0];
@@ -50,6 +61,7 @@ function getHtml(htmlSource) {
     } else {
       browser.tabs.update(undefined, {url: sciHubUrl + foundRegex});
     }
+    checkServerStatus();
   } else {
     browser.browserAction.setBadgeTextColor({ color: "white" });
     browser.browserAction.setBadgeBackgroundColor({ color: trueRed });

--- a/background.js
+++ b/background.js
@@ -45,7 +45,7 @@ function checkServerStatus() {
   img.height = 0;
   img.visibility = "hidden";
   img.onerror = function () {
-    if (confirm("Looks like "+sciHubUrl+" is dead.  Would you like to go to the options page to select a different mirror?")) {
+    if (confirm("Looks like the mirror "+sciHubUrl+" is dead.  Would you like to go to the options page to select a different mirror?")) {
       browser.tabs.create({url: 'chrome://extensions/?options=' + chrome.runtime.id}).then();
     }
   }

--- a/options.html
+++ b/options.html
@@ -1,17 +1,46 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <style>
+      table, th, td {
+        border: 1px solid black;
+        border-collapse: collapse;
+      }
+      td, th {border:  1px solid;
+        padding: 0px 10px;
+      }
+    </style>
   </head>
   <body>
     <h1>Sci-hub X Now!</h1>
     <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
       <p style="margin-right: 1em;">Sci-Hub url:</p>
       <input type="text" id="url"/>
+      <!-- <button type="button" id="autofetch">Auto-fetch</button> -->
     </div>
     <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
       <p style="margin-right: 1em;">Open in new tab:</p>
       <input type="checkbox" id="newtab" value="true"/>
     </div>
+    <hr />
+    <div>
+      Here is a list of back-up mirrors.
+      Click "select" to paste the mirror into the "Sci-hub URL" field above.
+    </div>
+    <div>
+      <table id="links" style="margin: auto;">
+        <th style="background-color: whitesmoke;" colspan="2">
+          Sci-hub back-up mirrors:
+        </th>
+      </table>
+    </div>
+    <div style="clear:both"></div>
+    <div style="margin:auto">
+      <p style="float:left; width:50px;">Legend: </p>
+      <p style="background-color: lightgreen; float:left; width:50px;">working</p>
+    <p style="background-color: pink; float:left; width:70px;">not working</p>
+    <div style="clear:both"></div>
+    <hr />
     <div>
       <p>
         Please visit the <a href="https://github.com/gchenfc/sci-hub-now/issues">github</a> to give feedback.

--- a/options.html
+++ b/options.html
@@ -19,8 +19,13 @@
       <!-- <button type="button" id="autofetch">Auto-fetch</button> -->
     </div>
     <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
-      <p style="margin-right: 1em;">Open in new tab:</p>
-      <input type="checkbox" id="newtab" value="true"/>
+      <input type="checkbox" id="newtab"/>
+    </div>
+    <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
+      <span style="margin-right: 1em;">
+        Auto-check sci-hub mirror on each paper request:
+      </span>
+      <input type="checkbox" id="autocheck" checked="true"/>
     </div>
     <hr />
     <div>

--- a/options.html
+++ b/options.html
@@ -42,8 +42,9 @@
     <div style="clear:both"></div>
     <div style="margin:auto">
       <p style="float:left; width:50px;">Legend: </p>
-      <p style="background-color: lightgreen; float:left; width:50px;">working</p>
-    <p style="background-color: pink; float:left; width:70px;">not working</p>
+      <p style="background-color: lightgreen; float:left; text-align: center; width:50px;">working</p>
+      <p style="background-color: pink; float:left; text-align: center; width:70px;">not working</p>
+      <p style="background-color: #aaa; float:left; text-align: center; width:50px;">loading</p>
     <div style="clear:both"></div>
     <hr />
     <div>

--- a/options.js
+++ b/options.js
@@ -60,6 +60,7 @@ function checkServerStatus(domain, i, ifOnline, ifOffline) {
 }
 
 updateStuffBool(document.getElementById("newtab"), "open-in-new-tab");
+updateStuffBool(document.getElementById("autocheck"), "autocheck-server");
 updateStuffString(document.getElementById("url"), "scihub-url", true);
 
 // fetch urls

--- a/options.js
+++ b/options.js
@@ -76,6 +76,7 @@ function fillUrls() {
   xmlhttp.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
       links = JSON.parse(this.responseText);
+      links.splice(3, 0, "https://deadlink.com/");
       for (const i in links) {
         linkstable.insertRow();
         linkstable.rows[linkstable.rows.length-1].innerHTML = "<td>"+links[i]+'</td><button id="link'+i+'">Select</button>';
@@ -84,6 +85,7 @@ function fillUrls() {
       console.log(linkstable.rows[links.length])
       console.log(links);
       for (const i in links) {
+        linkstable.rows[parseInt(i)+1].bgColor = "#aaa";
         checkServerStatus(links[i], i,
           function () {
             linkstable.rows[parseInt(i)+1].bgColor = "lightgreen";

--- a/options.js
+++ b/options.js
@@ -1,8 +1,16 @@
 'use strict';
 
-function updatePageString(field, propname) {
+function updatePageString(field, propname, isUrl) {
   chrome.storage.local.get([propname], function (result) {
     field.value = result[propname];
+    if (isUrl) {
+      checkServerStatus(field.value, -1,
+        function () {
+          field.style.backgroundColor = "lightgreen";
+        }, function () {
+          field.style.backgroundColor = "pink";
+        });
+    }
   })
 }
 function updatePageBool(field, propname) {
@@ -17,10 +25,18 @@ function updateStorage(val, propname) {
   var bgPage = chrome.extension.getBackgroundPage();
   bgPage.setthing(propname, val);
 }
-function updateStuffString(field, propname) {
-  updatePageString(field, propname);
+function updateStuffString(field, propname, isUrl) {
+  updatePageString(field, propname, isUrl);
   field.onkeyup = function () {
     updateStorage(field.value, propname);
+    if (isUrl) {
+      checkServerStatus(field.value, -1,
+        function () {
+          field.style.backgroundColor = "lightgreen";
+        }, function () {
+          field.style.backgroundColor = "pink";
+        });
+    }
   }
 }
 function updateStuffBool(field, propname) {
@@ -29,6 +45,68 @@ function updateStuffBool(field, propname) {
     updateStorage(field.checked, propname);
   }
 }
+function checkServerStatus(domain, i, ifOnline, ifOffline) {
+  var img = document.body.appendChild(document.createElement("img"));
+  img.height = 0;
+  img.visibility = "hidden";
+  img.onload = function () {
+    ifOnline && ifOnline.constructor == Function && ifOnline(i);
+  };
+  img.onerror = function () {
+    ifOffline && ifOffline.constructor == Function && ifOffline(i);
+  }
+  // img.src = domain + "/favicon.ico";
+  img.src = domain + "/misc/img/raven_1.png";
+}
 
-updateStuffString(document.getElementById("url"), "scihub-url");
 updateStuffBool(document.getElementById("newtab"), "open-in-new-tab");
+updateStuffString(document.getElementById("url"), "scihub-url", true);
+
+// fetch urls
+var links;
+var linkstable = document.getElementById("links");
+function setUrl(i) {
+  document.getElementById("url").value = links[i];
+  updateStorage(links[i], "scihub-url");
+}
+function fillUrls() {
+  var xmlhttp = new XMLHttpRequest();
+  xmlhttp.onreadystatechange = function() {
+    if (this.readyState == 4 && this.status == 200) {
+      links = JSON.parse(this.responseText);
+      for (const i in links) {
+        linkstable.insertRow();
+        linkstable.rows[linkstable.rows.length-1].innerHTML = "<td>"+links[i]+'</td><button id="link'+i+'">Select</button>';
+        document.getElementById("link" + i).onclick = function () { setUrl(i); }
+      }
+      console.log(linkstable.rows[links.length])
+      console.log(links);
+      for (const i in links) {
+        checkServerStatus(links[i], i,
+          function () {
+            linkstable.rows[parseInt(i)+1].bgColor = "lightgreen";
+          }, function () {
+            linkstable.rows[parseInt(i)+1].bgColor = "pink";
+          })
+      }
+    }
+  };
+  xmlhttp.open("GET", "https://raw.githubusercontent.com/gchenfc/sci-hub-now/master/activelinks.json", true);
+  xmlhttp.send();
+}
+fillUrls();
+// document.getElementById("autofetch").onclick = function () {
+//   function ifOnline(i) {
+//     console.log(links[i]+" is valid :)");
+//     console.log("working domain is "+links[i]);
+
+//     linkstable.rows[i+1].bgColor = "lightgreen";
+//     setUrl(i);
+//   };
+//   function ifOffline (i) {
+//     console.log(links[i]+" is INVALID");
+//     linkstable.rows[i+1].bgColor = "pink";
+//     checkServerStatus(links[i+1], i+1, ifOnline, ifOffline);
+//   };
+//   ifOffline(-1);
+// };

--- a/options.js
+++ b/options.js
@@ -68,6 +68,7 @@ var linkstable = document.getElementById("links");
 function setUrl(i) {
   document.getElementById("url").value = links[i];
   updateStorage(links[i], "scihub-url");
+  document.getElementById("url").style.backgroundColor = linkstable.rows[parseInt(i)+1].bgColor;
 }
 function fillUrls() {
   var xmlhttp = new XMLHttpRequest();


### PR DESCRIPTION
mirrors are referenced against activelinks.json on github
Addresses #6

Example options page:
![image](https://user-images.githubusercontent.com/25356161/104137799-83a37380-536d-11eb-884b-cb5eb85ea6d0.png)

This does not check that the domain is working each time you try to access a paper because I didn't want to slow down load times, but that would be easy to add.
