### PR TITLE
Go to right-clicked link

### DIFF
--- a/background.js
+++ b/background.js
@@ -86,7 +86,7 @@ function executeJs() {
 browser.contextMenus.create({
   id: "doi-selection",
   title: "Find article by DOI!",
-  contexts: ["selection"],
+  contexts: ["selection","link"],
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/background.js
+++ b/background.js
@@ -90,7 +90,10 @@ browser.contextMenus.create({
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
+  // if right-clicked on link, then parse link address first
   var doi = info.linkUrl;
+  doi = doi ? doi.match(doiRegex)[0].split(";")[0] : doi;
+  // if link not valid, try the highlighted text
   if (!doi) {
     doi = info.selectionText;
   }

--- a/background.js
+++ b/background.js
@@ -90,8 +90,12 @@ browser.contextMenus.create({
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
+  var doi = info.linkUrl;
+  if (!doi) {
+    doi = info.selectionText;
+  }
   var creatingTab = browser.tabs.create({
-    url: sciHubUrl + info.selectionText,
+    url: sciHubUrl + doi,
   });
 });
 


### PR DESCRIPTION
Previously, right clicking on a link would not add the "Find article by DOI" entry to the context menu.

This patch adds the following functionality:
Right-click on a DOI link and choose "Find article" to go to that article on Sci-Hub