### PR TITLE
Add default keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Unreleased
 
 ### Added
+- [#28](https://github.com/gchenfc/sci-hub-now/pull/28) Add default keyboard shortcuts
 - [#25](https://github.com/gchenfc/sci-hub-now/pull/25) Auto-download pdf & auto-naming
   - The user can opt to automatically download a pdf and bypass actually visiting sci-hub by enabling the setting in the options page.
   - Enabling auto-name will (if auto-download is enabled) automatically name the downloaded pdfs according to the naming convention `LastnameYearVenue_shorttitle.pdf`.  For example, `Grady19vppc_mostEfficientVehicle.pdf` for [10.1109/VPPC46532.2019.8952212](https://doi.org/10.1109/VPPC46532.2019.8952212).  Note that the `shorttitle` is almost always missing from the metadata.

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,16 @@
       }
     ]
   },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "windows": "Alt+A",
+        "mac": "Alt+A",
+        "chromeos": "Alt+A",
+        "linux": "Alt+A"
+      }
+    }
+  },
   "permissions": [
     "activeTab",
     "contextMenus",


### PR DESCRIPTION
Closes #21 

Google chrome actually already has support for user-level custom keyboard shortcuts for activating extensions:
[link](https://obie.ai/blog/how-to-add-and-remove-custom-keyboard-shortcuts-and-hotkeys-for-a-chrome-extension-in-5-seconds-flat/)
* Method 1:
  1. Go to manage extensions
  2. On the top left of the screen, click the three horizontal bars pull-out
  3. Click "Keyboard shortcuts"
* Method 2:
  1. Go to `chrome://extensions/shortcuts`

Nevertheless, chrome's API has an option for setting a "suggested" keyboard shortcut so I've set it to `alt-a` for all platforms.  Feedback would be appreciated in suggesting better default shortcuts.  I'm on mac and it doesn't seem to be conflicting with anything.  I like it because `alt-a` can be done with the left hand, and web browsing involves a lot of right-hand mouse clicking.

Note: I think you might have to "remove" then re-install the extension for the shortcut to take effect, as opposed to just clicking the little "refresh"/"update" icon on the extension.

@Nitrooo @jhelgert  Feel free to comment or open a new PR with alternative keybindings for other platforms.