### PR TITLE
Update server checking and pdf link extracting to work with more servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#18](https://github.com/gchenfc/sci-hub-now/pull/18) Context menu support (right click on a DOI link)
 
 ### Modified
+- [#29](https://github.com/gchenfc/sci-hub-now/pull/29) Updated server checking and pdf link parsing to deal with [https://sci-hubtw.hkvisa.net/](https://sci-hubtw.hkvisa.net/)-style mirrors.
 - [#24](https://github.com/gchenfc/sci-hub-now/pull/24) Icon changed for readibility in dark mode
 
 ## v0.1.0

--- a/background.js
+++ b/background.js
@@ -105,16 +105,29 @@ chrome.permissions.onRemoved.addListener(function (permissions) {
 });
 
 // Check server alive status
-function checkServerStatus() {
+function checkServerStatus(url) {
   var img = document.body.appendChild(document.createElement("img"));
   img.height = 0;
   img.visibility = "hidden";
   img.onerror = function () {
-    if (confirm("Looks like the mirror " + sciHubUrl + " is dead.  Would you like to go to the options page to select a different mirror?")) {
-      browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-    }
-  }
-  img.src = sciHubUrl + "/misc/img/raven_1.png";
+    var img2 = document.body.appendChild(document.createElement("img"));
+    img2.height = 0;
+    img2.visibility = "hidden";
+    img2.onload = function () { // didn't load raven but did load favicon
+      if (confirm("We detected that the mirror " + url + " might be dead." +
+        "\nIf the page/pdf actually loaded correctly, then there's no need for action and you may consider going to the options page to disable \"Auto-check sci-hub mirror on each paper request\"." +
+        "\nWould you like to go to the options page to select a different mirror or to turn off auto-checking?")) {
+        browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+      }
+    };
+    img2.onerror = function () { // didn't load either
+      if (confirm("Looks like the mirror " + url + " is dead.  Would you like to go to the options page to select a different mirror?")) {
+        browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+      }
+    };
+    img2.src = url + "/favicon.ico";
+  };
+  img.src = url + "/misc/img/raven_1.png";
 }
 
 // Automatic file name lookup & pdf downloading
@@ -195,7 +208,7 @@ function getHtml(htmlSource) {
       redirectToScihub(destUrl);
     }
     if (autoCheckServer) {
-      checkServerStatus();
+      checkServerStatus(sciHubUrl);
     }
   } else {
     // browser.browserAction.setBadgeTextColor({ color: "white" });

--- a/helper_js/pdf-link-scraper.js
+++ b/helper_js/pdf-link-scraper.js
@@ -1,9 +1,14 @@
-const pdfRegex = new RegExp("http.*\.pdf");
+const pdfRegex = new RegExp(/iframe\s*src\s*=\s*"(.*?\.pdf)/);
 
 function getPdfDownloadLink(htmlSource) {
   foundRegex = htmlSource.match(pdfRegex);
+  console.log(foundRegex);
   if (foundRegex) {
-    return foundRegex[0];
+    toReturn = foundRegex[1];
+    if (toReturn.startsWith("//")) { // quirk of sci-hub.st
+      toReturn = "https:" + toReturn;
+    }
+    return toReturn;
   }
 }
 

--- a/options.html
+++ b/options.html
@@ -91,6 +91,7 @@
     <div style="margin:auto">
       <p style="float:left; width:50px;">Legend: </p>
       <p style="background-color: lightgreen; float:left; text-align: center; width:50px;">working</p>
+      <p style="background-color: yellow; float:left; text-align: center; width:80px;">likely working</p>
       <p style="background-color: pink; float:left; text-align: center; width:70px;">not working</p>
       <p style="background-color: #aaa; float:left; text-align: center; width:50px;">loading</p>
     <div style="clear:both"></div>

--- a/options.js
+++ b/options.js
@@ -27,6 +27,7 @@ function initFields() {
 function initializeString(propname, isUrl, alternateCallback) {
   if (!alternateCallback) alternateCallback = () => { return Promise.resolve(null) };
   let field = getField(propname);
+  field.style.backgroundColor = "#aaa";
   field.value = propnameValueCache[propname];
   field.onchange = function () {
     field.onkeyup();
@@ -39,6 +40,8 @@ function initializeString(propname, isUrl, alternateCallback) {
       checkServerStatus(field.value, -1,
         function () {
           field.style.backgroundColor = "lightgreen";
+        }, function () {
+          field.style.backgroundColor = "yellow";
         }, function () {
           field.style.backgroundColor = "pink";
         });
@@ -150,19 +153,29 @@ chrome.storage.onChanged.addListener((changes, area) => {
 
 
 // Code related to color-coding and populating sci-hub links
-
-function checkServerStatus(domain, i, ifOnline, ifOffline) {
+function checkServerStatus(domain, i, ifOnline, ifProbablyOnline, ifOffline) {
+  checkServerStatusHelper(domain + "/favicon.ico", i,
+    function () {
+      checkServerStatusHelper(domain + "/misc/img/raven_1.png", i,
+        ifOnline,
+        ifProbablyOnline,
+        ifProbablyOnline);
+    },
+    ifOffline,
+    function () { });
+}
+function checkServerStatusHelper(testurl, i, ifOnline, ifOffline, ifWaiting) {
   var img = document.body.appendChild(document.createElement("img"));
   img.height = 0;
   img.visibility = "hidden";
+  ifWaiting && ifWaiting.constructor == Function && ifWaiting(i);
   img.onload = function () {
     ifOnline && ifOnline.constructor == Function && ifOnline(i);
   };
   img.onerror = function () {
     ifOffline && ifOffline.constructor == Function && ifOffline(i);
   }
-  // img.src = domain + "/favicon.ico";
-  img.src = domain + "/misc/img/raven_1.png";
+  img.src = testurl;
 }
 
 // fetch urls
@@ -193,6 +206,8 @@ function fillUrls() {
         checkServerStatus(links[i], i,
           function () {
             linkstable.rows[parseInt(i) + 1].bgColor = "lightgreen";
+          }, function () {
+            linkstable.rows[parseInt(i) + 1].bgColor = "yellow";
           }, function () {
             linkstable.rows[parseInt(i) + 1].bgColor = "pink";
           })


### PR DESCRIPTION
Some servers (I noticed the ones based on [https://sci-hubtw.hkvisa.net/](https://sci-hubtw.hkvisa.net/)) have 2 differences which make them not work properly with this extension:
1. Their `raven_1.png` file is hosted on a different site ([sci-hub.shop](https://img.sci-hub.shop/scihub/ravenround.gif)) for some reason, and this was the way that I was doing automated checks to see if the link was dead.  Therefore, those automated checks weren't working properly.  In response, I now check the server for a `favicon` first, then if it passes that then also test for the raven picture.  If it passes only the favicon but not the raven, then I mark it yellow: "likely working".
2. Their pdf links don't start with `https://` but instead just start with `//`, so I modified the regex pattern to look for the iframe instead, and then added a manual check if the link begins with `//` then prepend `https:`.