### PR TITLE
Remove duplicate '/' in dead-link checking

### DIFF
--- a/options.js
+++ b/options.js
@@ -164,9 +164,11 @@ chrome.storage.onChanged.addListener((changes, area) => {
 
 // Code related to color-coding and populating sci-hub links
 function checkServerStatus(domain, i, ifOnline, ifProbablyOnline, ifOffline) {
-  checkServerStatusHelper(domain + "/favicon.ico", i,
+  if (domain.charAt(domain.length - 1) != '/')
+    domain = domain + '/';
+  checkServerStatusHelper(domain + "favicon.ico", i,
     function () {
-      checkServerStatusHelper(domain + "/misc/img/raven_1.png", i,
+      checkServerStatusHelper(domain + "misc/img/raven_1.png", i,
         ifOnline,
         ifProbablyOnline,
         ifProbablyOnline);

--- a/options.js
+++ b/options.js
@@ -168,7 +168,7 @@ function checkServerStatus(domain, i, ifOnline, ifProbablyOnline, ifOffline) {
     domain = domain + '/';
   checkServerStatusHelper(domain + "favicon.ico", i,
     function () {
-      checkServerStatusHelper(domain + "misc/img/raven_1.png", i,
+      checkServerStatusHelper(domain + "pictures/ravenround_hs.gif", i,
         ifOnline,
         ifProbablyOnline,
         ifProbablyOnline);


### PR DESCRIPTION
This is a "mini-" bugfix for the fact that we incorrectly classify sci-hub.se as broken when it is not broken.  This is because there was an extra '/' in the url path for link checking.