### PR TITLE
Upgrade to Manifest v3

### DIFF
--- a/helper_js/browser.js
+++ b/helper_js/browser.js
@@ -18,17 +18,9 @@ async function doAlert(message) {
     args: [message],
   }).catch(reason => {
     console.log("Failed to trigger alert, trying to open popup: ", reason);
-    // browser.tabs.update({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then(tab => {
-    //   return chrome.scripting.executeScript({
-    //     target: { tabId: tab.id },
-    //     func: () => {
-    //       document.querySelector(".modal").style.display = 'block';
-    //       document.querySelector(".modal-body").innerHTML = text;
-    //     }
-    //   });
-    // });
-    // browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-    // chrome.tabs.create({ url: "helper_js/notif-popup.html" });
+    browser.storage.local.set({ 'error-message': message });
+    // open options page
+    browser.tabs.update({ url: 'chrome://extensions/?options=' + chrome.runtime.id });
   });
 };
 

--- a/helper_js/browser.js
+++ b/helper_js/browser.js
@@ -1,0 +1,35 @@
+// Add some random hacks related to chrome and MV3/unable to use `alert`.
+
+// webextension-polyfill.js (firefox)
+if (!('browser' in self)) {
+  self.browser = self.chrome;
+}
+
+// Util function to do an alert using Manifest v3.  Usage:
+//  await doAlert("message");
+// `tab` must be passed in from a callback.
+async function doAlert(message) {
+  console.log("Trying to trigger alert with message: ", message);
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const activeTab = tabs[0];
+  return chrome.scripting.executeScript({
+    target: { tabId: activeTab.id },
+    func: (message) => { alert(message); },
+    args: [message],
+  }).catch(reason => {
+    console.log("Failed to trigger alert, trying to open popup: ", reason);
+    // browser.tabs.update({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then(tab => {
+    //   return chrome.scripting.executeScript({
+    //     target: { tabId: tab.id },
+    //     func: () => {
+    //       document.querySelector(".modal").style.display = 'block';
+    //       document.querySelector(".modal-body").innerHTML = text;
+    //     }
+    //   });
+    // });
+    // browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+    // chrome.tabs.create({ url: "helper_js/notif-popup.html" });
+  });
+};
+
+export { doAlert }

--- a/helper_js/browser.js
+++ b/helper_js/browser.js
@@ -40,4 +40,60 @@ async function doConfirm(message) {
   });
 }
 
-export { doAlert, doConfirm }
+// On Install / upgrade / downgrade
+// Variable Initialization
+const install_message =
+  "Thank you for installing Sci-Hub X Now!\n" +
+  "Check out the options page to customize your experience! :)"
+const update_message =
+  "Thank you for upgrading Sci-Hub X Now!\n" +
+  "We have new features!\n" +
+  'Check out the "options" page now to enable them! :)';
+function onInstall(details) {
+  if (details.reason == "install") {
+    doAlert(install_message).then(() => { browser.runtime.openOptionsPage(); });
+    browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+  }
+  if (details.reason == "update") {
+    function parseVersion(version) {
+      const parts = version.split(".");
+      const major = parseInt(parts[0], 10);
+      const minor = parseInt(parts[1], 10);
+      const bugfix = parseInt(parts[2], 10);
+
+      return { major, minor, bugfix };
+    }
+    let previousVersion = parseVersion(details.previousVersion);
+    let current_version = parseVersion(chrome.runtime.getManifest().version);
+
+    let major_update = current_version.major > previousVersion.major;
+    let minor_update =
+      current_version.major == previousVersion.major &&
+      current_version.minor > previousVersion.minor;
+    let bugfix_update =
+      current_version.major == previousVersion.major &&
+      current_version.minor == previousVersion.minor &&
+      current_version.bugfix > previousVersion.bugfix;
+    let no_update = current_version == previousVersion;
+
+    if (major_update) {
+      console.log("A major version update has occurred.");
+      doConfirm(update_message).then(() => { browser.runtime.openOptionsPage(); });
+    } else if (minor_update) {
+      console.log("A minor version update has occurred.");
+      doConfirm(update_message).then(() => { browser.runtime.openOptionsPage(); });
+    } else if (bugfix_update) {
+      console.log("A bugfix version update has occurred.");
+    } else if (no_update) {
+      console.log("No update has occurred.");
+    } else {
+      console.log("A downdate has occurred.");
+    }
+  }
+}
+
+function addListeners() {
+  chrome.runtime.onInstalled.addListener(onInstall);
+}
+
+export { doAlert, doConfirm, addListeners }

--- a/helper_js/browser.js
+++ b/helper_js/browser.js
@@ -14,7 +14,7 @@ async function doAlert(message) {
   const activeTab = tabs[0];
   return chrome.scripting.executeScript({
     target: { tabId: activeTab.id },
-    func: (message) => { alert(message); },
+    func: (message) => { alert("From Sci-Hub X Now! extension: " + message); },
     args: [message],
   }).catch(reason => {
     console.log("Failed to trigger alert, trying to open popup: ", reason);
@@ -23,5 +23,21 @@ async function doAlert(message) {
     browser.tabs.update({ url: 'chrome://extensions/?options=' + chrome.runtime.id });
   });
 };
+async function doConfirm(message) {
+  console.log("Trying to trigger alert with message: ", message);
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const activeTab = tabs[0];
+  return chrome.scripting.executeScript({
+    target: { tabId: activeTab.id },
+    func: (message) => confirm("From Sci-Hub X Now! extension: " + message),
+    args: [message],
+  }).then(resp => resp[0].result).catch(reason => {
+    console.log("Failed to trigger alert, trying to open popup: ", reason);
+    browser.storage.local.set({ 'error-message': message });
+    // open options page
+    browser.tabs.update({ url: 'chrome://extensions/?options=' + chrome.runtime.id });
+    return false;
+  });
+}
 
-export { doAlert }
+export { doAlert, doConfirm }

--- a/helper_js/check-server-alive.js
+++ b/helper_js/check-server-alive.js
@@ -1,6 +1,26 @@
+import { doConfirm } from "./browser.js"
+
+function checkServerStatus(url, timeout = 1000) {
+  const controller = new AbortController();
+  setTimeout(() => { controller.abort() }, timeout);
+  fetch(url, { signal: controller.signal })
+    .then(() => {
+      console.log("CHECK VALID SUCCESS");
+    })
+    .catch((err) => {
+      console.log("CHECK VALID FAILED", err);
+      doConfirm("We detected that the mirror " + url + " might be dead." +
+        "\nIf the page/pdf actually loaded correctly, then there's no need for action and you may consider going to the options page to disable \"Auto-check sci-hub mirror on each paper request\"." +
+        "\nWould you like to go to the options page to select a different mirror or to turn off auto-checking?").then((yesno) => {
+          if (yesno) {
+            browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id });
+          }
+        });
+    });
+}
 /************* BEGIN SERVER ALIVE CHECKING CODE ****************** */
 let FILES_TO_CHECK = ["favicon.ico", "misc/img/raven_1.png", "pictures/ravenround_hs.gif"]
-function checkServerStatus(domain) {
+function checkServerStatusOld(domain) {
   var counts = [0, 0];
   var sent_message = false;
 
@@ -43,6 +63,8 @@ function checkServerStatus(domain) {
 }
 function checkServerStatusHelper(testurl, callback) {
   // TDOO(gerry): use virtual DOM defined in chrome extension mv3 docs
+  // edit: actually this requires additional chrome permissions, so I think it's best to just
+  //  request host/CORS permissions for sci-hub.se instead.
   var img = document.body.appendChild(document.createElement("img"));
   img.height = 0;
   img.visibility = "hidden";

--- a/helper_js/check-server-alive.js
+++ b/helper_js/check-server-alive.js
@@ -1,0 +1,59 @@
+/************* BEGIN SERVER ALIVE CHECKING CODE ****************** */
+let FILES_TO_CHECK = ["favicon.ico", "misc/img/raven_1.png", "pictures/ravenround_hs.gif"]
+function checkServerStatus(domain) {
+  var counts = [0, 0];
+  var sent_message = false;
+
+  console.log("CHECKING SERVER STATUS FOR ", domain);
+
+  if (domain.charAt(domain.length - 1) != '/')
+    domain = domain + '/';
+  for (const file of FILES_TO_CHECK.values())
+    checkServerStatusHelper(domain + file, function (success) {
+      if (sent_message) { return; }
+      console.log("IN CALLBACK! counts is ", counts);
+      counts[0] += 1;
+      if (success) counts[1] += 1;
+      if (counts[0] < FILES_TO_CHECK.length) { return; }
+      if ((counts[1] == 0)) {
+        if (confirm("Looks like the mirror " + domain + " is dead.  Would you like to go to the options page to select a different mirror?")) {
+          browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+        }
+      } else if (counts[1] == 1) {
+        if (confirm("We detected that the mirror " + domain + " might be dead." +
+          "\nIf the page/pdf actually loaded correctly, then there's no need for action and you may consider going to the options page to disable \"Auto-check sci-hub mirror on each paper request\"." +
+          "\nWould you like to go to the options page to select a different mirror or to turn off auto-checking?")) {
+          browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+        }
+      } else {
+        // all good
+      }
+      sent_message = true;
+    });
+
+  setTimeout(function () {
+    if (sent_message) { return; }
+    if (counts[0] < FILES_TO_CHECK.length) {
+      if (confirm("Looks like the mirror " + domain + " is dead.  Would you like to go to the options page to select a different mirror?")) {
+        browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+      }
+    }
+    sent_message = true;
+  }, 2000);
+}
+function checkServerStatusHelper(testurl, callback) {
+  // TDOO(gerry): use virtual DOM defined in chrome extension mv3 docs
+  var img = document.body.appendChild(document.createElement("img"));
+  img.height = 0;
+  img.visibility = "hidden";
+  img.onload = function () {
+    callback && callback.constructor == Function && callback(true);
+  };
+  img.onerror = function () {
+    callback && callback.constructor == Function && callback(false);
+  }
+  img.src = testurl;
+}
+/************* END SERVER ALIVE CHECKING CODE ****************** */
+
+export { checkServerStatus };

--- a/helper_js/config.js
+++ b/helper_js/config.js
@@ -1,0 +1,133 @@
+
+// Old and less strict DOI regex.
+// const doiRegex = "10.\\d{4,9}/[-._;()/:a-z0-9A-Z]+";
+const doiRegex = new RegExp(
+  /\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/
+);
+
+// Variable management constants
+var sciHubUrl;
+var autodownload = false;
+var autoname = false;
+var openInNewTab = false;
+var autoCheckServer = true;
+var venueAbbreviations = {};
+const defaults = {
+  "autodownload": false,
+  "scihub-url": "https://sci-hub.st/",
+  "autoname": false,
+  "open-in-new-tab": false,
+  "autocheck-server": false,
+  "venue-abbreviations": {},
+};
+// Variable management functions
+function printVars() {
+  console.log("sciHubUrl: " + sciHubUrl +
+    "\nautodownload: " + autodownload +
+    "\nautoname: " + autoname +
+    "\nopenInNewTab: " + openInNewTab +
+    "\nautoCheckServer: " + autoCheckServer);
+}
+function addListeners() {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local') {
+      for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
+        setvariable(key, newValue);
+        console.log(`Changed "${key}" from "${oldValue}" to "${newValue}".`);
+      }
+    }
+  });
+}
+function setvariable(name, value) {
+  switch (name) {
+    case "scihub-url":
+      sciHubUrl = value;
+      break;
+    case "autodownload":
+      autodownload = value;
+      break;
+    case "autoname":
+      autoname = value;
+      break;
+    case "open-in-new-tab":
+      openInNewTab = value;
+      break;
+    case "autocheck-server":
+      autoCheckServer = value;
+      break;
+    case "venue-abbreviations":
+      venueAbbreviations = value;
+      break;
+  }
+  console.log("setvariable called!!!");
+  printVars();
+}
+function initialize(name, value) {
+  console.log("initializing " + name + ": " + value);
+  setvariable(name, value);
+}
+
+// Variable Initialization
+chrome.runtime.onInstalled.addListener(function (details) {
+  // Set variables to default if they don't already exist
+  chrome.storage.local.get(defaults, function (result) {
+    console.log("Initializing variables onInstalled: ", result);
+    chrome.storage.local.set(result); // for if variables were not set
+  });
+
+  if (details.reason == "install") {
+    browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
+  }
+  if (details.reason == "update") {
+    function parseVersion(version) {
+      const parts = version.split(".");
+      const major = parseInt(parts[0], 10);
+      const minor = parseInt(parts[1], 10);
+      const bugfix = parseInt(parts[2], 10);
+
+      return { major, minor, bugfix };
+    }
+    let previousVersion = parseVersion(details.previousVersion);
+    let current_version = parseVersion(chrome.runtime.getManifest().version);
+
+    let major_update = current_version.major > previousVersion.major;
+    let minor_update =
+      current_version.major == previousVersion.major &&
+      current_version.minor > previousVersion.minor;
+    let bugfix_update =
+      current_version.major == previousVersion.major &&
+      current_version.minor == previousVersion.minor &&
+      current_version.bugfix > previousVersion.bugfix;
+    let no_update = current_version == previousVersion;
+
+    let update_message =
+      "Thank you for upgrading Sci-Hub X Now!\n" +
+      "We have new features!\n" +
+      'Would you like to go to the "options" page now to enable them?';
+    if (major_update) {
+      console.log("A major version update has occurred.");
+      if (confirm(update_message)) {
+        browser.runtime.openOptionsPage();
+      }
+    } else if (minor_update) {
+      console.log("A minor version update has occurred.");
+      if (confirm(update_message)) {
+        browser.runtime.openOptionsPage();
+      }
+    } else if (bugfix_update) {
+      console.log("A bugfix version update has occurred.");
+    } else if (no_update) {
+      console.log("No update has occurred.");
+    } else {
+      console.log("A downdate has occurred.");
+    }
+  }
+});
+chrome.storage.local.get(defaults, function (result) {
+  for (const property in result) {
+    console.log("Initializing ", property, ": ", result[property]);
+    initialize(property, result[property]);
+  }
+});
+
+export { doiRegex, sciHubUrl, autodownload, autoname, openInNewTab, autoCheckServer, venueAbbreviations, addListeners };

--- a/helper_js/config.js
+++ b/helper_js/config.js
@@ -28,15 +28,13 @@ function printVars() {
     "\nopenInNewTab: " + openInNewTab +
     "\nautoCheckServer: " + autoCheckServer);
 }
-function addListeners() {
-  chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'local') {
-      for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
-        setvariable(key, newValue);
-        console.log(`Changed "${key}" from "${oldValue}" to "${newValue}".`);
-      }
+function onChangedListener(changes, area) {
+  if (area === 'local') {
+    for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
+      setvariable(key, newValue);
+      console.log(`Changed "${key}" from "${oldValue}" to "${newValue}".`);
     }
-  });
+  }
 }
 function setvariable(name, value) {
   switch (name) {
@@ -62,72 +60,31 @@ function setvariable(name, value) {
   console.log("setvariable called!!!");
   printVars();
 }
-function initialize(name, value) {
+function initializeVar(name, value) {
   console.log("initializing " + name + ": " + value);
   setvariable(name, value);
 }
 
-// Variable Initialization
-chrome.runtime.onInstalled.addListener(function (details) {
+chrome.storage.local.get(defaults, function (result) {
+  for (const property in result) {
+    console.log("Initializing ", property, ": ", result[property]);
+    initializeVar(property, result[property]);
+  }
+});
+
+
+// Initialization, on install / upgrade / downgrade
+function initialize(details) {
   // Set variables to default if they don't already exist
   chrome.storage.local.get(defaults, function (result) {
     console.log("Initializing variables onInstalled: ", result);
     chrome.storage.local.set(result); // for if variables were not set
   });
+}
 
-  if (details.reason == "install") {
-    browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-  }
-  if (details.reason == "update") {
-    function parseVersion(version) {
-      const parts = version.split(".");
-      const major = parseInt(parts[0], 10);
-      const minor = parseInt(parts[1], 10);
-      const bugfix = parseInt(parts[2], 10);
-
-      return { major, minor, bugfix };
-    }
-    let previousVersion = parseVersion(details.previousVersion);
-    let current_version = parseVersion(chrome.runtime.getManifest().version);
-
-    let major_update = current_version.major > previousVersion.major;
-    let minor_update =
-      current_version.major == previousVersion.major &&
-      current_version.minor > previousVersion.minor;
-    let bugfix_update =
-      current_version.major == previousVersion.major &&
-      current_version.minor == previousVersion.minor &&
-      current_version.bugfix > previousVersion.bugfix;
-    let no_update = current_version == previousVersion;
-
-    let update_message =
-      "Thank you for upgrading Sci-Hub X Now!\n" +
-      "We have new features!\n" +
-      'Would you like to go to the "options" page now to enable them?';
-    if (major_update) {
-      console.log("A major version update has occurred.");
-      if (confirm(update_message)) {
-        browser.runtime.openOptionsPage();
-      }
-    } else if (minor_update) {
-      console.log("A minor version update has occurred.");
-      if (confirm(update_message)) {
-        browser.runtime.openOptionsPage();
-      }
-    } else if (bugfix_update) {
-      console.log("A bugfix version update has occurred.");
-    } else if (no_update) {
-      console.log("No update has occurred.");
-    } else {
-      console.log("A downdate has occurred.");
-    }
-  }
-});
-chrome.storage.local.get(defaults, function (result) {
-  for (const property in result) {
-    console.log("Initializing ", property, ": ", result[property]);
-    initialize(property, result[property]);
-  }
-});
+function addListeners() {
+  chrome.storage.onChanged.addListener(onChangedListener);
+  chrome.runtime.onInstalled.addListener(initialize);
+}
 
 export { doiRegex, sciHubUrl, autodownload, autoname, openInNewTab, autoCheckServer, venueAbbreviations, addListeners };

--- a/helper_js/doi-metadata-scraper.js
+++ b/helper_js/doi-metadata-scraper.js
@@ -1,5 +1,15 @@
 const metadataRegex = new RegExp(/.*?\|([^\|]+?)\|([^\|]+?)\|[^\|]*?\|[^\|]*?\|[^\|]*?\|([^\|]+?)\|[^\|]*?\|([^\|]*?)\|([^\|]*)/);
 
+function getApiQueryUrl(doi, email) {
+  return 'https://doi.crossref.org/servlet/query' + '?pid=' + email + '&id=' + doi;
+}
+
+function createFilenameFromMetadata(md) {
+  if (!md)
+    return undefined;
+  return md.authorlastname + md.yearmod100 + md.shortvenue + "_" + md.shorttitle + '.pdf';
+}
+
 function extractLastName(fullname) {
   let lastname = fullname.match(/.*\s(.*)/);
   if (lastname) {
@@ -8,6 +18,8 @@ function extractLastName(fullname) {
     return fullname;
   }
 };
+
+var venueAbbreviations; // TODO(gerry): fix the visibility of variables
 function abbreviateVenue(venue) {
   // First loop through our hard-coded list
   for (const property in venueAbbreviations) {
@@ -28,10 +40,11 @@ function abbreviateVenue(venue) {
   capitalLetters.forEach((v, i) => { capitalLetters[i] = v[0] }); // drop second letter of each chunk
   return capitalLetters.join('').toLowerCase();
 };
+
 function extractMetadata(metadata_str) {
   let matches = metadata_str.match(metadataRegex);
   if (!matches) {
-    doAlert("Error 27: Could not parse the metadata file!\n\n" + metadata_str + "\nSaving with default filename.");
+    doAlert("Error 27: Could not parse the metadata file!\n\n" + metadata_str + "\nSaving with default filename.").then(() => { return null });
     return null;
   }
   let metadata = {
@@ -48,6 +61,4 @@ function extractMetadata(metadata_str) {
   return metadata;
 };
 
-// extractMetadata(document.body.innerText);
-
-export { extractMetadata };
+export { getApiQueryUrl, createFilenameFromMetadata, extractMetadata };

--- a/helper_js/doi-metadata-scraper.js
+++ b/helper_js/doi-metadata-scraper.js
@@ -31,7 +31,7 @@ function abbreviateVenue(venue) {
 function extractMetadata(metadata_str) {
   let matches = metadata_str.match(metadataRegex);
   if (!matches) {
-    alert("Error 27: Could not parse the metadata file!\n\n" + metadata_str + "\nSaving with default filename.");
+    doAlert("Error 27: Could not parse the metadata file!\n\n" + metadata_str + "\nSaving with default filename.");
     return null;
   }
   let metadata = {

--- a/helper_js/doi-metadata-scraper.js
+++ b/helper_js/doi-metadata-scraper.js
@@ -2,7 +2,8 @@ import { venueAbbreviations } from "./config.js";
 
 const metadataRegex = new RegExp(/.*?\|([^\|]+?)\|([^\|]+?)\|[^\|]*?\|[^\|]*?\|[^\|]*?\|([^\|]+?)\|[^\|]*?\|([^\|]*?)\|([^\|]*)/);
 
-function getApiQueryUrl(doi, email) {
+const EMAIL = 'gchenfc.developer@gmail.com';
+function getApiQueryUrl(doi, email = EMAIL) {
   return 'https://doi.crossref.org/servlet/query' + '?pid=' + email + '&id=' + doi;
 }
 
@@ -43,6 +44,7 @@ function abbreviateVenue(venue) {
 };
 
 function extractMetadata(metadata_str) {
+  console.log("metadata html contents:", metadata_str);
   let matches = metadata_str.match(metadataRegex);
   if (!matches) {
     doAlert("Error 27: Could not parse the metadata file!\n\n" + metadata_str + "\nSaving with default filename.").then(() => { return null });
@@ -59,6 +61,7 @@ function extractMetadata(metadata_str) {
   metadata.shortvenue = abbreviateVenue(metadata.venue);
   metadata.yearmod100 = metadata.year.slice(-2);
 
+  console.log("metadata extracted:", metadata);
   return metadata;
 };
 

--- a/helper_js/doi-metadata-scraper.js
+++ b/helper_js/doi-metadata-scraper.js
@@ -49,3 +49,5 @@ function extractMetadata(metadata_str) {
 };
 
 // extractMetadata(document.body.innerText);
+
+export { extractMetadata };

--- a/helper_js/doi-metadata-scraper.js
+++ b/helper_js/doi-metadata-scraper.js
@@ -1,3 +1,5 @@
+import { venueAbbreviations } from "./config.js";
+
 const metadataRegex = new RegExp(/.*?\|([^\|]+?)\|([^\|]+?)\|[^\|]*?\|[^\|]*?\|[^\|]*?\|([^\|]+?)\|[^\|]*?\|([^\|]*?)\|([^\|]*)/);
 
 function getApiQueryUrl(doi, email) {
@@ -19,7 +21,6 @@ function extractLastName(fullname) {
   }
 };
 
-var venueAbbreviations; // TODO(gerry): fix the visibility of variables
 function abbreviateVenue(venue) {
   // First loop through our hard-coded list
   for (const property in venueAbbreviations) {

--- a/helper_js/download_utils.js
+++ b/helper_js/download_utils.js
@@ -1,0 +1,10 @@
+async function httpGetText(theUrl) {
+  // TODO(gerry): add a timeout, e.g. via 
+  // https://stackoverflow.com/questions/46946380/fetch-api-request-timeout/57888548#57888548
+  // https://stackoverflow.com/questions/31061838/how-do-i-cancel-an-http-fetch-request/47250621#47250621
+  return fetch(theUrl)
+    .then(response => response.text())
+    .catch(error => { throw error; });
+}
+
+export { httpGetText };

--- a/helper_js/pdf-link-scraper.js
+++ b/helper_js/pdf-link-scraper.js
@@ -20,3 +20,5 @@ function getPdfDownloadLink(htmlSource) {
 }
 
 // getPdfDownloadLink(document.body.innerHTML);
+
+export { getPdfDownloadLink };

--- a/helper_js/pdf-link-scraper.js
+++ b/helper_js/pdf-link-scraper.js
@@ -4,15 +4,21 @@ const pdfRegexes = [
   new RegExp(/iframe\s*src\s*=\s*"([^"]*?\.pdf)/)
 ];
 
-function getPdfDownloadLink(htmlSource) {
+function getPdfDownloadLink(urlRoot, htmlSource) {
   for (let pdfRegex of pdfRegexes) {
     console.log("regex is: ", pdfRegex);
-    foundRegex = htmlSource.match(pdfRegex);
+    const foundRegex = htmlSource.match(pdfRegex);
     console.log("foundRegex is: ", foundRegex);
     if (foundRegex) {
-      toReturn = foundRegex[1];
+      let toReturn = foundRegex[1];
+      console.log("toReturn is: ", toReturn);
       if (toReturn.startsWith("//")) { // quirk of sci-hub.st
+        console.log("toReturn starts with //");
         toReturn = "https:" + toReturn;
+      }
+      if (toReturn.startsWith("/")) { // download link is relative to site root
+        toReturn = urlRoot + toReturn;
+        console.log("toReturn starts with /.  New link is ", toReturn);
       }
       return toReturn;
     }

--- a/helper_js/permissions-manager.js
+++ b/helper_js/permissions-manager.js
@@ -1,3 +1,7 @@
+import { sciHubUrl, autodownload } from "./config.js";
+import { doAlert } from "./browser.js";
+import { getApiQueryUrl } from "./doi-metadata-scraper.js";
+
 const promisifyPermission = (func, ...args) => {
   return new Promise((resolve, reject) => {
     func(...args, (result) => {
@@ -7,13 +11,14 @@ const promisifyPermission = (func, ...args) => {
   });
 }
 
+// CORS for DOI metadata fetching
 function metadataFailMsg() {
   return "The permission request for \"Sci-Hub X Now!\" to access the doi metadata query service by https://doi.crossref.org failed." +
     "\nThe auto-naming feature will now be disabled but other functionality" + (propnameValueCache["autodownload"] ? " (including auto-downloading) " : " ") + "will continue to work." +
     "\nYou may re-enable auto-naming at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-name downloaded pdf's\" checkbox.";
 }
 function requestCorsPermissionMetadata() {
-  request = {
+  const request = {
     origins: ['https://doi.crossref.org/servlet/query*']
   };
   return promisifyPermission(chrome.permissions.contains, request)
@@ -29,6 +34,7 @@ function requestCorsPermissionMetadata() {
     );
 }
 
+// CORS for sci-hub pdf link grabbing
 function scihubFailMsg(sciHubUrl) {
   return "The permission request for \"Sci-Hub X Now!\" to access the sci hub url: `" + sciHubUrl + "` failed." +
     "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
@@ -53,3 +59,43 @@ function requestCorsPermissionScihub(sciHubUrl) {
       }
     );
 }
+
+// On permissions changes
+// TODO(gerry): fix this.
+function addListeners() {
+  chrome.permissions.onRemoved.addListener(function (permissions) {
+    console.log("permissions revoked!!!", permissions)
+    const tmpPermissions = permissions;
+    // TODO: doAlert won't work because it's inside a chrome:// tab which is permissions protected.
+    // One workaround is to save the reason auto-download was disabled and then display it when the user next opens the options page.
+    const alertAndDisableAutoname = (msg) => {
+      doAlert(msg).finally(() => { chrome.storage.local.set({ "autoname": false }); });
+    };
+    const alertAndDisableDownload = (msg) => {
+      doAlert(msg).finally(() => { chrome.storage.local.set({ "autodownload": false }); });
+    };
+    for (var origin of permissions.origins) {
+      origin = origin.replaceAll("*", ".*"); // to match regex syntax
+      console.log(origin, getApiQueryUrl("", ""));
+      if (getApiQueryUrl("", "").match(origin)) {
+        alertAndDisableAutoname("You've removed the permission for \"Sci-Hub X Now!\" to access the doi metadata query service by https://doi.crossref.org." +
+          "\nThe auto-naming feature will now be disabled but other functionality" + (autodownload ? " (including auto-downloading) " : " ") + "will continue to work." +
+          "\nYou may re-enable auto-naming at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-name downloaded pdf's\" checkbox.");
+      }
+      if (sciHubUrl.match(origin)) {
+        alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to access the sci hub url: `" + sciHubUrl + "`." +
+          "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
+          "\nYou may re-enable auto-downloading at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-download pdf's\" checkbox.");
+      }
+    }
+    for (const permission of permissions.permissions) {
+      if (permission === "downloads") {
+        alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to automatically download files." +
+          "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
+          "\nYou may re-enable auto-downloading at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-download pdf's\" checkbox.");
+      }
+    }
+  });
+}
+
+export { requestCorsPermissionMetadata, requestCorsPermissionScihub, addListeners };

--- a/helper_js/permissions-manager.js
+++ b/helper_js/permissions-manager.js
@@ -84,7 +84,7 @@ function addListeners() {
       }
       if (sciHubUrl.match(origin)) {
         alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to access the sci hub url: `" + sciHubUrl + "`." +
-          "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
+          "\nThe \"auto-download\" and \"auto-check server alive\" features will now be disabled but redirecting doi's to sci-hub will continue to work." +
           "\nYou may re-enable auto-downloading at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-download pdf's\" checkbox.");
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Sci-Hub X Now!",
   "short_name": "sci-hub-x-now",
   "version": "0.2.2",
@@ -10,7 +10,7 @@
     "48": "icons/48x48.png",
     "96": "icons/96x96.png"
   },
-  "browser_action": {
+  "action": {
     "browser_style": true,
     "default_icon": {
       "48": "icons/48x48.png",
@@ -31,7 +31,7 @@
     ]
   },
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "windows": "Alt+A",
         "mac": "Alt+A",
@@ -43,20 +43,19 @@
   "permissions": [
     "activeTab",
     "contextMenus",
+    "scripting",
     "storage"
   ],
   "optional_permissions": [
-    "downloads",
+    "downloads"
+  ],
+  "optional_host_permissions": [
     "https://doi.crossref.org/servlet/query*",
     "*://*/*"
   ],
   "background": {
-    "scripts": [
-      "browser-polyfill.js",
-      "background.js",
-      "helper_js/doi-metadata-scraper.js",
-      "helper_js/pdf-link-scraper.js"
-    ]
+    "service_worker": "service_worker.js",
+    "type": "module"
   },
   "options_page": "options.html",
   "options_ui": {

--- a/options.html
+++ b/options.html
@@ -35,6 +35,29 @@
       .separator:not(:empty)::after {
         margin-left: .25em;
       }
+
+      /* The Modal (background) */
+      .modal {
+        display: none;
+        position: fixed;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background-color: rgb(0, 0, 0);
+        background-color: rgba(0, 0, 0, 0.4);
+      }
+
+      /* Modal Content/Box */
+      .modal-content {
+        background-color: #fefefe;
+        margin: 15% auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width: 80%;
+      }
     </style>
   </head>
   <body>
@@ -104,6 +127,25 @@
         Please visit the <a href="https://github.com/gchenfc/sci-hub-now/issues">github</a> to give feedback.
       </p>
     </div>
+
+    <!-- We use modal as an alternative to `alert` -->
+    <div class="modal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2 class="modal-title">Alert</h2>
+          </div>
+          <div class="modal-body" id="error-message" style="margin: 20px 0;">
+            <p>Modal body text goes here.</p>
+          </div>
+          <div class="modal-footer">
+            <!-- <button type="button" onclick="document.querySelector('.modal').style.display='none';"> -->
+            <button id="close-modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </body>
   <script type="module" src="options.js"></script>
 </html>

--- a/options.html
+++ b/options.html
@@ -105,6 +105,5 @@
       </p>
     </div>
   </body>
-  <script src="helper_js/permissions-manager.js"></script>
-  <script src="options.js"></script>
+  <script type="module" src="options.js"></script>
 </html>

--- a/options.html
+++ b/options.html
@@ -91,12 +91,13 @@
     <div class="option">
       <input type="checkbox" id="autocheck" checked="true"/>
       <span style="margin-left: 0.5em;" title="Automatically check if the sci-hub mirror is down each time you click the extension">
-        Auto-check sci-hub mirror on each paper request
+        Auto-check sci-hub mirror on each paper request <sup>3</sup>
       </span>
     </div>
     <div style="font-size: 6pt; margin-bottom: 1em;">
       <sup>1</sup> requires permissions to manage downloads and access <code>&lt;scihub-url&gt;</code> (to get the pdf link) <br />
-      <sup>2</sup> requires permissions to access <code>doi.crossref.org</code> for metadata lookup
+      <sup>2</sup> requires permissions to access <code>doi.crossref.org</code> for metadata lookup <br />
+      <sup>3</sup> requires permissions to access <code>&lt;scihub-url&gt;</code>
     </div>
     <div class="separator">Mirrors</div>
     <div>

--- a/options.js
+++ b/options.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { requestCorsPermissionMetadata, requestCorsPermissionScihub } from './helper_js/permissions-manager.js';
+
 // Field access
 const propnameFieldnameMap = {
   "autodownload": "autodownload",
@@ -40,8 +42,8 @@ function initializeString(propname, isUrl, alternateCallback) {
       field.style.backgroundColor = "#aaa";
       master_link_count = [0, 0];
       setTimeout(checkServerStatus, 250, field.value, function (success) {
-          update_master_link_count(field.style, success);
-        });
+        update_master_link_count(field.style, success);
+      });
     }
   };
   field.onkeyup(); // colorize the initial text box
@@ -52,9 +54,12 @@ function initializeBool(propname, alternateCallback) {
   field.checked = propnameValueCache[propname];
   field.onchange = function () {
     console.log(propname + " callback!");
-    alternateCallback(field.checked).then(
-      () => { updateStorage(field.checked, propname); },
-      (reason) => { chrome.extension.getBackgroundPage().alert(reason); });
+    alternateCallback(field.checked)
+      .then(() => { updateStorage(field.checked, propname); })
+      .catch(
+        // (reason) => { chrome.extension.getBackgroundPage().alert(reason); });
+        (reason) => { alert(reason); console.log("Rejected due to ", reason); }
+      );
   };
 }
 
@@ -103,7 +108,6 @@ function scihuburlCallback(url) {
   console.log("url callback");
   return autodownloadCallback(propnameValueCache["autodownload"]);
 }
-function noop() { }
 
 // Variable storage
 function updateStorage(val, propname) {

--- a/options.js
+++ b/options.js
@@ -63,6 +63,20 @@ function initializeBool(propname, alternateCallback) {
   };
 }
 
+// Alert modal
+async function doAlert() {
+  const data = await browser.storage.local.get('error-message')
+  if (!data['error-message']) return;
+  browser.storage.local.remove('error-message'); // clear the error message so it doesn't show up again
+  console.log('error message is: ', data['error-message']);
+  document.querySelector('#error-message').textContent = data['error-message'];
+  document.querySelector(".modal").style.display = 'block';
+}
+doAlert();
+document.getElementById("close-modal").addEventListener("click", function () {
+  document.querySelector(".modal").style.display = 'none';
+});
+
 // Callbacks
 function autodownloadCallback(checked) {
   console.log("autodownload callback: " + checked);

--- a/options.js
+++ b/options.js
@@ -20,11 +20,11 @@ function initFields() {
   initializeBool("autodownload", autodownloadCallback);
   initializeBool("autoname", autonameCallback);
   initializeBool("open-in-new-tab");
-  initializeBool("autocheck-server");
+  initializeBool("autocheck-server", autocheckServerCallback);
   initializeString("scihub-url", true, scihuburlCallback);
-  // autodownloadCallback(propnameValueCache["autodownload"]);
   autodownloadCallback(propnameValueCache["autodownload"]);
   autonameCallback(propnameValueCache["autoname"]);
+  autocheckServerCallback(propnameValueCache["autocheck-server"]);
 };
 function initializeString(propname, isUrl, alternateCallback) {
   if (!alternateCallback) alternateCallback = () => { return Promise.resolve(null) };
@@ -84,17 +84,21 @@ function autodownloadCallback(checked) {
   getField("open-in-new-tab").disabled = checked;
   if (checked) {
     return new Promise((resolve, reject) => {
-      requestCorsPermissionScihub(propnameValueCache["scihub-url"]).then(
-        (reason) => { console.log("completed scihub callback"); resolve(reason) },
-        (reason) => {
-          console.log("Scihub permission request failed");
-          updateStorage(false, "autodownload");
-          getField("autodownload").checked = false;
-          getField("autoname").disabled = true;
-          getField("open-in-new-tab").disabled = checked;
-          reject(reason);
-        }
-      );
+      requestCorsPermissionScihub(propnameValueCache["scihub-url"])
+        .then(
+          (reason) => {
+            getField("open-in-new-tab").checked = false;
+            console.log("completed scihub callback"); resolve(reason)
+          })
+        .catch(
+          (reason) => {
+            console.log("Scihub permission request failed");
+            updateStorage(false, "autodownload");
+            getField("autodownload").checked = false;
+            getField("autoname").disabled = true;
+            getField("open-in-new-tab").disabled = false;
+            reject(reason);
+          });
     });
   } else {
     return Promise.resolve("no additional permissions required");
@@ -104,20 +108,40 @@ function autonameCallback(checked) {
   console.log("autoname callback: " + checked);
   if (checked) {
     return new Promise((resolve, reject) => {
-      requestCorsPermissionMetadata().then(
-        (reason) => { console.log("completed metadata callback"); resolve(reason) },
-        (reason) => {
-          console.log("Metadata permission request failed");
-          updateStorage(false, "autoname");
-          getField("autoname").checked = false;
-          reject(reason);
-        }
-      );
+      requestCorsPermissionMetadata()
+        .then(
+          (reason) => { console.log("completed metadata callback"); resolve(reason) })
+        .catch(
+          (reason) => {
+            console.log("Metadata permission request failed");
+            updateStorage(false, "autoname");
+            getField("autoname").checked = false;
+            reject(reason);
+          });
     });
   } else {
     return Promise.resolve("no additional permissions required");
   }
 }
+function autocheckServerCallback(checked) {
+  console.log("autocheckServer callback: " + checked);
+  if (checked) {
+    return new Promise((resolve, reject) => {
+      requestCorsPermissionScihub(propnameValueCache["scihub-url"])
+        .then(
+          (reason) => { console.log("completed scihub callback"); resolve(reason) })
+        .catch(
+          (reason) => {
+            console.log("Scihub permission request failed");
+            updateStorage(false, "autocheck-server");
+            getField("autocheck-server").checked = false;
+            reject(reason);
+          });
+    });
+  } else {
+    return Promise.resolve("no additional permissions required");
+  }
+};
 function scihuburlCallback(url) {
   console.log("url callback");
   return autodownloadCallback(propnameValueCache["autodownload"]);
@@ -128,7 +152,7 @@ function updateStorage(val, propname) {
   propnameValueCache[propname] = val;
   var obj = {};
   obj[propname] = val;
-  chrome.storage.local.set(obj, function () { });
+  chrome.storage.local.set(obj);
   console.log("updated storage for " + propname + ": " + val);
 };
 
@@ -187,7 +211,7 @@ function checkServerStatus(domain, callback) {
 function checkServerStatusHelper(testurl, callback) {
   var img = document.body.appendChild(document.createElement("img"));
   img.height = 0;
-  img.visibility = "hidden";
+  img.style.display = "none";
   img.onload = function () {
     callback && callback.constructor == Function && callback(true);
   };
@@ -226,6 +250,17 @@ function update_counts(i, success) {
   console.log("colored: ", linkstable.rows[i + 1]);
 }
 
+// Currently unused method of checking the server alive state.  Requires host / CORS permissions.
+function checkServer(url, timeout) {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const options = { mode: 'no-cors', signal };
+  return fetch(url, options)
+    .then(setTimeout(() => { controller.abort() }, timeout))
+    .then(response => console.log('Check server response:', response.statusText, response.ok, response.text(), response.body, response))
+    .catch(error => console.error('Check server error:', error.message));
+}
+
 // Fetch data from database
 const databaseRoot = "https://raw.githubusercontent.com/gchenfc/sci-hub-now/master/data/";
 // const databaseRoot = "data/"; // For local testing
@@ -258,6 +293,10 @@ function fillUrls() {
         setTimeout(checkServerStatus, 250, links[i], function (success) {
           update_counts(parseInt(i), success)
         })
+        // checkServer(links[i], 1000).then(success => {
+        //   linkstable.rows[parseInt(i) + 1].bgColor = "lightgreen";
+        // }).catch(error => {
+        //   linkstable.rows[parseInt(i) + 1].bgColor = "pink";});
       }
     }
   };

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,5 +1,5 @@
 import { doiRegex, sciHubUrl, autodownload, autoname, openInNewTab, autoCheckServer, addListeners as addConfigListeners } from "./helper_js/config.js"
-import { doAlert } from "./helper_js/browser.js"
+import { doAlert, addListeners as addBrowserListeners } from "./helper_js/browser.js"
 import { getPdfDownloadLink } from "./helper_js/pdf-link-scraper.js"
 import { getApiQueryUrl, createFilenameFromMetadata, extractMetadata } from "./helper_js/doi-metadata-scraper.js"
 import { httpGetText } from "./helper_js/download_utils.js"
@@ -9,6 +9,7 @@ import { checkServerStatus } from "./helper_js/check-server-alive.js"
 // All imported event listeners
 addConfigListeners();
 addPermissionsListeners();
+addBrowserListeners();
 
 // Automatic file name lookup & pdf downloading
 function downloadPaper(link, fname, scihublink) {

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,246 +1,14 @@
+import { doiRegex, sciHubUrl, autodownload, autoname, openInNewTab, autoCheckServer, addListeners as addConfigListeners } from "./helper_js/config.js"
+import { doAlert } from "./helper_js/browser.js"
 import { getPdfDownloadLink } from "./helper_js/pdf-link-scraper.js"
 import { getApiQueryUrl, createFilenameFromMetadata, extractMetadata } from "./helper_js/doi-metadata-scraper.js"
 import { httpGetText } from "./helper_js/download_utils.js"
+import { addListeners as addPermissionsListeners } from "./helper_js/permissions-manager.js"
+import { checkServerStatus } from "./helper_js/check-server-alive.js"
 
-// webextension-polyfill.js (firefox)
-if (!('browser' in self)) {
-  self.browser = self.chrome;
-}
-
-// Util function to do an alert using Manifest v3.  Usage:
-//  await doAlert("message");
-// `tab` must be passed in from a callback.
-async function doAlert(message) {
-  console.log("Trying to trigger alert with message: ", message);
-  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-  const activeTab = tabs[0];
-  return chrome.scripting.executeScript({
-    target: { tabId: activeTab.id },
-    func: (message) => { alert(message); },
-    args: [message],
-  });
-};
-function alertAndRedirect(msg, destUrl) {
-  doAlert(msg).then(() => redirectToScihub(destUrl));
-}
-
-// Old and less strict DOI regex.
-// const doiRegex = "10.\\d{4,9}/[-._;()/:a-z0-9A-Z]+";
-const doiRegex = new RegExp(
-  /\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/
-);
-const trueRed = "#BC243C";
-
-// Variable management constants
-var sciHubUrl;
-var autodownload = false;
-var autoname = false;
-var openInNewTab = false;
-var autoCheckServer = true;
-var venueAbbreviations = {};
-const defaults = {
-  "autodownload": false,
-  "scihub-url": "https://sci-hub.st/",
-  "autoname": false,
-  "open-in-new-tab": false,
-  "autocheck-server": false,
-  "venue-abbreviations": {}
-};
-// Variable management functions
-function printVars() {
-  console.log("sciHubUrl: " + sciHubUrl +
-    "\nautodownload: " + autodownload +
-    "\nautoname: " + autoname +
-    "\nopenInNewTab: " + openInNewTab +
-    "\nautoCheckServer: " + autoCheckServer);
-}
-chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local') {
-    for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
-      setvariable(key, newValue);
-      console.log(`Changed "${key}" from "${oldValue}" to "${newValue}".`);
-    }
-  }
-});
-function setvariable(name, value) {
-  switch (name) {
-    case "scihub-url":
-      sciHubUrl = value;
-      break;
-    case "autodownload":
-      autodownload = value;
-      break;
-    case "autoname":
-      autoname = value;
-      break;
-    case "open-in-new-tab":
-      openInNewTab = value;
-      break;
-    case "autocheck-server":
-      autoCheckServer = value;
-      break;
-    case "venue-abbreviations":
-      venueAbbreviations = value;
-      break;
-  }
-  console.log("setvariable called!!!");
-  printVars();
-}
-function initialize(name, value) {
-  console.log("initializing " + name + ": " + value);
-  setvariable(name, value);
-}
-
-// Variable Initialization
-chrome.runtime.onInstalled.addListener(function (details) {
-  // Set variables to default if they don't already exist
-  chrome.storage.local.get(defaults, function (result) {
-    console.log("Initializing variables onInstalled: ", result);
-    chrome.storage.local.set(result); // for if variables were not set
-  });
-
-  if (details.reason == "install") {
-    browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-  }
-  if (details.reason == "update") {
-    function parseVersion(version) {
-      const parts = version.split(".");
-      const major = parseInt(parts[0], 10);
-      const minor = parseInt(parts[1], 10);
-      const bugfix = parseInt(parts[2], 10);
-
-      return { major, minor, bugfix };
-    }
-    let previousVersion = parseVersion(details.previousVersion);
-    let current_version = parseVersion(chrome.runtime.getManifest().version);
-
-    let major_update = current_version.major > previousVersion.major;
-    let minor_update =
-      current_version.major == previousVersion.major &&
-      current_version.minor > previousVersion.minor;
-    let bugfix_update =
-      current_version.major == previousVersion.major &&
-      current_version.minor == previousVersion.minor &&
-      current_version.bugfix > previousVersion.bugfix;
-    let no_update = current_version == previousVersion;
-
-    let update_message =
-      "Thank you for upgrading Sci-Hub X Now!\n" +
-      "We have new features!\n" +
-      'Would you like to go to the "options" page now to enable them?';
-    if (major_update) {
-      console.log("A major version update has occurred.");
-      if (confirm(update_message)) {
-        browser.runtime.openOptionsPage();
-      }
-    } else if (minor_update) {
-      console.log("A minor version update has occurred.");
-      if (confirm(update_message)) {
-        browser.runtime.openOptionsPage();
-      }
-    } else if (bugfix_update) {
-      console.log("A bugfix version update has occurred.");
-    } else if (no_update) {
-      console.log("No update has occurred.");
-    } else {
-      console.log("A downdate has occurred.");
-    }
-  }
-});
-chrome.storage.local.get(defaults, function (result) {
-  for (const property in result) {
-    initialize(property, result[property]);
-  }
-});
-// Special case: permission revoked:
-var tmpPermissions;
-chrome.permissions.onRemoved.addListener(function (permissions) {
-  console.log("permissions revoked!!!", permissions)
-  tmpPermissions = permissions;
-  // TODO: doAlert won't work because it's inside a chrome:// tab which is permissions protected.
-  // One workaround is to save the reason auto-download was disabled and then display it when the user next opens the options page.
-  const alertAndDisableDownload = (msg) => {
-    doAlert(msg).then(() => { chrome.storage.local.set({ "autodownload": false }); });
-  };
-  for (var origin of permissions.origins) {
-    origin = origin.replaceAll("*", ".*"); // to match regex syntax
-    console.log(origin, getApiQueryUrl("", ""));
-    if (getApiQueryUrl("", "").match(origin)) {
-      alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to access the doi metadata query service by https://doi.crossref.org." +
-        "\nThe auto-naming feature will now be disabled but other functionality" + (autodownload ? " (including auto-downloading) " : " ") + "will continue to work." +
-        "\nYou may re-enable auto-naming at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-name downloaded pdf's\" checkbox.");
-    }
-    if (sciHubUrl.match(origin)) {
-      alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to access the sci hub url: `" + sciHubUrl + "`." +
-        "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
-        "\nYou may re-enable auto-downloading at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-download pdf's\" checkbox.");
-    }
-  }
-  for (const permission of permissions.permissions) {
-    if (permission === "downloads") {
-      alertAndDisableDownload("You've removed the permission for \"Sci-Hub X Now!\" to automatically download files." +
-        "\nThe auto-download feature will now be disabled but redirecting doi's to sci-hub will continue to work." +
-        "\nYou may re-enable auto-downloading at any time by going to the options page (right click the extension icon and click \"Options\") then selecting the \"Auto-download pdf's\" checkbox.");
-    }
-  }
-});
-
-/************* BEGIN SERVER ALIVE CHECKING CODE ****************** */
-let FILES_TO_CHECK = ["favicon.ico", "misc/img/raven_1.png", "pictures/ravenround_hs.gif"]
-function checkServerStatus(domain) {
-  var counts = [0, 0];
-  var sent_message = false;
-
-  console.log("CHECKING SERVER STATUS FOR ", domain);
-
-  if (domain.charAt(domain.length - 1) != '/')
-    domain = domain + '/';
-  for (const file of FILES_TO_CHECK.values())
-    checkServerStatusHelper(domain + file, function (success) {
-      if (sent_message) { return; }
-      console.log("IN CALLBACK! counts is ", counts);
-      counts[0] += 1;
-      if (success) counts[1] += 1;
-      if (counts[0] < FILES_TO_CHECK.length) { return; }
-      if ((counts[1] == 0)) {
-        if (confirm("Looks like the mirror " + domain + " is dead.  Would you like to go to the options page to select a different mirror?")) {
-          browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-        }
-      } else if (counts[1] == 1) {
-        if (confirm("We detected that the mirror " + domain + " might be dead." +
-          "\nIf the page/pdf actually loaded correctly, then there's no need for action and you may consider going to the options page to disable \"Auto-check sci-hub mirror on each paper request\"." +
-          "\nWould you like to go to the options page to select a different mirror or to turn off auto-checking?")) {
-          browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-        }
-      } else {
-        // all good
-      }
-      sent_message = true;
-    });
-
-  setTimeout(function () {
-    if (sent_message) { return; }
-    if (counts[0] < FILES_TO_CHECK.length) {
-      if (confirm("Looks like the mirror " + domain + " is dead.  Would you like to go to the options page to select a different mirror?")) {
-        browser.tabs.create({ url: 'chrome://extensions/?options=' + chrome.runtime.id }).then();
-      }
-    }
-    sent_message = true;
-  }, 2000);
-}
-function checkServerStatusHelper(testurl, callback) {
-  var img = document.body.appendChild(document.createElement("img"));
-  img.height = 0;
-  img.visibility = "hidden";
-  img.onload = function () {
-    callback && callback.constructor == Function && callback(true);
-  };
-  img.onerror = function () {
-    callback && callback.constructor == Function && callback(false);
-  }
-  img.src = testurl;
-}
-/************* END SERVER ALIVE CHECKING CODE ****************** */
+// All imported event listeners
+addConfigListeners();
+addPermissionsListeners();
 
 // Automatic file name lookup & pdf downloading
 function downloadPaper(link, fname, scihublink) {
@@ -272,6 +40,9 @@ function redirectToScihub(destUrl) {
     browser.tabs.update(undefined, { url: destUrl });
   }
 }
+function alertAndRedirect(msg, destUrl) {
+  doAlert(msg).then(() => redirectToScihub(destUrl));
+}
 
 function downloadPaperWithMetadata(url, metadata = undefined) {
   var pdfLink = '';
@@ -290,6 +61,34 @@ function downloadPaperWithMetadata(url, metadata = undefined) {
       alertAndRedirect("Error 25: Failed to obtain download link - redirecting to sci-hub...", url);
     });
 }
+function main(doi) {
+  console.log("RUNNING MAIN ON ", doi);
+  const destUrl = sciHubUrl + doi;
+  if (autodownload) {
+    if (autoname) {
+      const email = 'gchenfc.developer@gmail.com';
+      httpGetText(getApiQueryUrl(doi, email))
+        .then(contents => {
+          console.log("metadata html contents:", contents);
+          const metadata = extractMetadata(contents);
+          console.log("metadata extracted:", metadata);
+          return downloadPaperWithMetadata(destUrl, metadata);
+        })
+        .catch(err => {
+          console.log("Error 24: Failed to obtain metadata (err: ", err, ") - redirecting to sci-hub...", destUrl)
+          alertAndRedirect("Error 24: Failed to obtain metadata (err: " + err + ") - redirecting to sci-hub...", destUrl)
+        });
+    } else {
+      return downloadPaperWithMetadata(destUrl, undefined);
+    }
+  } else {
+    redirectToScihub(destUrl);
+  }
+  if (autoCheckServer) {
+    setTimeout(checkServerStatus, 1, sciHubUrl);
+  }
+}
+
 // Primary callback upon icon click
 function getHtml(htmlSource) {
   htmlSource = htmlSource[0];
@@ -297,34 +96,11 @@ function getHtml(htmlSource) {
   if (foundRegex) {
     var doi = foundRegex[0].split(";")[0];
     doi = doi.replace(/\.pdf/, "");
-    var destUrl = sciHubUrl + doi;
     // console.log("Regex: " + foundRegex);
-    if (autodownload) {
-      if (autoname) {
-        const email = 'gchenfc.developer@gmail.com';
-        httpGetText(getApiQueryUrl(doi, email))
-          .then(contents => {
-            console.log("metadata html contents:", contents);
-            const metadata = extractMetadata(contents);
-            console.log("metadata extracted:", metadata);
-            return downloadPaperWithMetadata(destUrl, metadata);
-          })
-          .catch(err => {
-            console.log("Error 24: Failed to obtain metadata (err: ", err, ") - redirecting to sci-hub...", destUrl)
-            alertAndRedirect("Error 24: Failed to obtain metadata (err: ", err, ") - redirecting to sci-hub...", destUrl)
-          });
-      } else {
-        return downloadPaperWithMetadata(destUrl, undefined);
-      }
-    } else {
-      redirectToScihub(destUrl);
-    }
-    if (autoCheckServer) {
-      setTimeout(checkServerStatus, 1, sciHubUrl);
-    }
+    main(doi);
   } else {
     // browser.action.setBadgeTextColor({ color: "white" });
-    browser.action.setBadgeBackgroundColor({ color: trueRed });
+    browser.action.setBadgeBackgroundColor({ color: "#BC243C" });
     browser.action.setBadgeText({ text: ":'(" });
   }
 }
@@ -354,9 +130,10 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
   if (!doi) {
     doi = info.selectionText;
   }
-  var creatingTab = browser.tabs.create({
-    url: sciHubUrl + doi,
-  });
+  // var creatingTab = browser.tabs.create({
+  //   url: sciHubUrl + doi,
+  // });
+  main(doi);
 });
 
 // Badge stuff


### PR DESCRIPTION
Needed various changes to be compatible with Manifest v3

Although this was on the TODO list for a while, it became urgent when the extension was taken off the chrome store, since all new extensions require Manifest v3.

Also, some refactoring was done.